### PR TITLE
bug: fix image on notes page

### DIFF
--- a/lib/ui/screens/home_page/pages/notes_page/notes_page.dart
+++ b/lib/ui/screens/home_page/pages/notes_page/notes_page.dart
@@ -136,7 +136,7 @@ class NotesPageBody extends StatelessWidget {
                         crossAxisAlignment: CrossAxisAlignment.center,
                         children: [
                           SvgPicture.asset(
-                            'assets/illustrations/add_friend-01.svg',// 'assets/illustrations/add_notes.svg',
+                            'assets/illustrations/add_notes.svg',
                             width: screenWidth * 0.80,
                           ),
                           SizedBox(height: screenHeight * 0.040236341),


### PR DESCRIPTION
### Description
Fixes the 'image, not displayed' error in the notes page

Fixes #9 

### Flutter Channel:
- [x] I have used the Flutter Beta channel on my local machine 

### Type of Change:
**Delete irrelevant options.**

- Code

**Code/Quality Assurance Only**
- Bug fix (non-breaking change which fixes an issue)

### How Has This Been Tested?
Tested on a physical device

### Checklist:

- [x] My PR follows the style guidelines of this project
- [x] I have performed a self-review of my own code or materials
- [x] I have commented my code or provided relevant documentation, particularly in hard-to-understand areas

**Code/Quality Assurance Only**
- [x] My changes generate no new warnings