### PR TITLE
 fix: dialog context error feat: delete friend

### DIFF
--- a/android/settings.gradle
+++ b/android/settings.gradle
@@ -1,15 +1,30 @@
-// Copyright 2014 The Flutter Authors. All rights reserved.
-// Use of this source code is governed by a BSD-style license that can be
-// found in the LICENSE file.
+// // Copyright 2014 The Flutter Authors. All rights reserved.
+// // Use of this source code is governed by a BSD-style license that can be
+// // found in the LICENSE file.
 
+// include ':app'
+
+// def localPropertiesFile = new File(rootProject.projectDir, "local.properties")
+// def properties = new Properties()
+
+// assert localPropertiesFile.exists()
+// localPropertiesFile.withReader("UTF-8") { reader -> properties.load(reader) }
+
+// def flutterSdkPath = properties.getProperty("flutter.sdk")
+// assert flutterSdkPath != null, "flutter.sdk not set in local.properties"
+// apply from: "$flutterSdkPath/packages/flutter_tools/gradle/app_plugin_loader.gradle"
 include ':app'
 
-def localPropertiesFile = new File(rootProject.projectDir, "local.properties")
-def properties = new Properties()
+def flutterProjectRoot = rootProject.projectDir.parentFile.toPath()
 
-assert localPropertiesFile.exists()
-localPropertiesFile.withReader("UTF-8") { reader -> properties.load(reader) }
+def plugins = new Properties()
+def pluginsFile = new File(flutterProjectRoot.toFile(), '.flutter-plugins')
+if (pluginsFile.exists()) {
+    pluginsFile.withReader('UTF-8') { reader -> plugins.load(reader) }
+}
 
-def flutterSdkPath = properties.getProperty("flutter.sdk")
-assert flutterSdkPath != null, "flutter.sdk not set in local.properties"
-apply from: "$flutterSdkPath/packages/flutter_tools/gradle/app_plugin_loader.gradle"
+plugins.each { name, path ->
+    def pluginDirectory = flutterProjectRoot.resolve(path).resolve('android').toFile()
+    include ":$name"
+    project(":$name").projectDir = pluginDirectory
+}

--- a/android/settings.gradle
+++ b/android/settings.gradle
@@ -13,18 +13,3 @@ localPropertiesFile.withReader("UTF-8") { reader -> properties.load(reader) }
 def flutterSdkPath = properties.getProperty("flutter.sdk")
 assert flutterSdkPath != null, "flutter.sdk not set in local.properties"
 apply from: "$flutterSdkPath/packages/flutter_tools/gradle/app_plugin_loader.gradle"
-// include ':app'
-
-// def flutterProjectRoot = rootProject.projectDir.parentFile.toPath()
-
-// def plugins = new Properties()
-// def pluginsFile = new File(flutterProjectRoot.toFile(), '.flutter-plugins')
-// if (pluginsFile.exists()) {
-//     pluginsFile.withReader('UTF-8') { reader -> plugins.load(reader) }
-// }
-
-// plugins.each { name, path ->
-//     def pluginDirectory = flutterProjectRoot.resolve(path).resolve('android').toFile()
-//     include ":$name"
-//     project(":$name").projectDir = pluginDirectory
-// }

--- a/android/settings.gradle
+++ b/android/settings.gradle
@@ -2,29 +2,29 @@
 // // Use of this source code is governed by a BSD-style license that can be
 // // found in the LICENSE file.
 
-// include ':app'
-
-// def localPropertiesFile = new File(rootProject.projectDir, "local.properties")
-// def properties = new Properties()
-
-// assert localPropertiesFile.exists()
-// localPropertiesFile.withReader("UTF-8") { reader -> properties.load(reader) }
-
-// def flutterSdkPath = properties.getProperty("flutter.sdk")
-// assert flutterSdkPath != null, "flutter.sdk not set in local.properties"
-// apply from: "$flutterSdkPath/packages/flutter_tools/gradle/app_plugin_loader.gradle"
 include ':app'
 
-def flutterProjectRoot = rootProject.projectDir.parentFile.toPath()
+def localPropertiesFile = new File(rootProject.projectDir, "local.properties")
+def properties = new Properties()
 
-def plugins = new Properties()
-def pluginsFile = new File(flutterProjectRoot.toFile(), '.flutter-plugins')
-if (pluginsFile.exists()) {
-    pluginsFile.withReader('UTF-8') { reader -> plugins.load(reader) }
-}
+assert localPropertiesFile.exists()
+localPropertiesFile.withReader("UTF-8") { reader -> properties.load(reader) }
 
-plugins.each { name, path ->
-    def pluginDirectory = flutterProjectRoot.resolve(path).resolve('android').toFile()
-    include ":$name"
-    project(":$name").projectDir = pluginDirectory
-}
+def flutterSdkPath = properties.getProperty("flutter.sdk")
+assert flutterSdkPath != null, "flutter.sdk not set in local.properties"
+apply from: "$flutterSdkPath/packages/flutter_tools/gradle/app_plugin_loader.gradle"
+// include ':app'
+
+// def flutterProjectRoot = rootProject.projectDir.parentFile.toPath()
+
+// def plugins = new Properties()
+// def pluginsFile = new File(flutterProjectRoot.toFile(), '.flutter-plugins')
+// if (pluginsFile.exists()) {
+//     pluginsFile.withReader('UTF-8') { reader -> plugins.load(reader) }
+// }
+
+// plugins.each { name, path ->
+//     def pluginDirectory = flutterProjectRoot.resolve(path).resolve('android').toFile()
+//     include ":$name"
+//     project(":$name").projectDir = pluginDirectory
+// }

--- a/lib/api/functions/friends_functions.dart
+++ b/lib/api/functions/friends_functions.dart
@@ -191,11 +191,11 @@ class FriendFunctions {
   }
 
   static Future<void> deleteFriend({@required String id}) async {
-    print(id);
     final _listExp = getCurrentExpenses;
     _listExp.forEach((element) async {
       if (element.to == id) {
         await ExpensesFunctions.deleteExpense(id: element.id);
+        getCurrentExpenses.remove(element);
       }
     });
     await _firestore

--- a/lib/api/functions/friends_functions.dart
+++ b/lib/api/functions/friends_functions.dart
@@ -1,7 +1,9 @@
 import 'package:cloud_firestore/cloud_firestore.dart';
+import 'package:contri_app/api/functions/expenses_functions.dart';
 import 'package:contri_app/api/models/friend_model.dart';
 import 'package:contri_app/api/models/user_model.dart';
 import 'package:contri_app/global/global_helpers.dart';
+import 'package:flutter/material.dart';
 
 class FriendFunctions {
   static final _firestore = Firestore.instance;
@@ -186,5 +188,21 @@ class FriendFunctions {
 
       return _docId;
     }
+  }
+
+  static Future<void> deleteFriend({@required String id}) async {
+    print(id);
+    final _listExp = getCurrentExpenses;
+    _listExp.forEach((element) async {
+      if (element.to == id) {
+        await ExpensesFunctions.deleteExpense(id: element.id);
+      }
+    });
+    await _firestore
+        .collection('users')
+        .document(globalUser.id)
+        .collection('friends')
+        .document(id)
+        .delete();
   }
 }

--- a/lib/ui/components/addNewFriend.dart
+++ b/lib/ui/components/addNewFriend.dart
@@ -46,7 +46,8 @@ class _AddNewFriendDialogState extends State<AddNewFriendDialog> {
           onPressed: () {
             Navigator.of(context).pop();
             // Another 'pop' to restrict the user form adding expense with a NULL user
-            Navigator.of(context).pop();
+            //TODO: comment
+            // Navigator.of(context).pop();
           },
           child: Text("CANCEL"),
         ),

--- a/lib/ui/components/addNewFriend.dart
+++ b/lib/ui/components/addNewFriend.dart
@@ -46,7 +46,7 @@ class _AddNewFriendDialogState extends State<AddNewFriendDialog> {
           onPressed: () {
             Navigator.of(context).pop();
             // Another 'pop' to restrict the user form adding expense with a NULL user
-            //TODO: comment
+            //Commented the statement below as it was popping the homepage.
             // Navigator.of(context).pop();
           },
           child: Text("CANCEL"),

--- a/lib/ui/components/custom_appBar.dart
+++ b/lib/ui/components/custom_appBar.dart
@@ -6,12 +6,14 @@ class CustomAppBar extends StatelessWidget implements PreferredSizeWidget {
   final double expandableHeight;
   final Widget leading;
   final Widget title;
+  final List<Widget> actions;
   CustomAppBar({
     @required this.height,
     @required this.expandableHeight,
     @required this.child,
     this.leading,
     this.title,
+    this.actions,
   });
 
   @override
@@ -20,6 +22,7 @@ class CustomAppBar extends StatelessWidget implements PreferredSizeWidget {
   @override
   Widget build(BuildContext context) {
     return SliverAppBar(
+      actions: actions,
       stretch: true,
       automaticallyImplyLeading: false,
       expandedHeight: expandableHeight,

--- a/lib/ui/components/delete_friend_dialog.dart
+++ b/lib/ui/components/delete_friend_dialog.dart
@@ -1,0 +1,42 @@
+import 'package:contri_app/api/functions/friends_functions.dart';
+import 'package:contri_app/ui/global/utils.dart';
+import 'package:flutter/material.dart';
+
+class DeleteFriendDialog extends StatelessWidget {
+  final Function onPressed;
+  final String title;
+  final String content;
+  DeleteFriendDialog({
+    @required this.title,
+    @required this.content,
+    @required this.onPressed,
+  });
+  @override
+  Widget build(BuildContext context) {
+    return AlertDialog(
+      title: Text(
+        title,
+        style: Theme.of(context)
+            .textTheme
+            .headline1
+            .copyWith(fontSize: screenHeight * 0.022246941),
+      ),
+      content: Text(
+        content,
+        style: Theme.of(context).textTheme.bodyText1.copyWith(),
+      ),
+      actions: [
+        FlatButton(
+          child: Text('Cancel'),
+          onPressed: () {
+            Navigator.of(context).pop();
+          },
+        ),
+        FlatButton(
+          child: Text('Delete'),
+          onPressed: onPressed,
+        ),
+      ],
+    );
+  }
+}

--- a/lib/ui/screens/detailed_expense_page/bloc/detailexp_bloc.dart
+++ b/lib/ui/screens/detailed_expense_page/bloc/detailexp_bloc.dart
@@ -2,6 +2,7 @@ import 'dart:async';
 
 import 'package:bloc/bloc.dart';
 import 'package:contri_app/api/functions/expenses_functions.dart';
+import 'package:contri_app/api/functions/friends_functions.dart';
 import 'package:contri_app/api/functions/group_functions.dart';
 import 'package:contri_app/global/global_helpers.dart';
 import 'package:contri_app/global/storage_constants.dart';
@@ -196,6 +197,12 @@ class DetailexpBloc extends Bloc<DetailexpEvent, DetailexpState> {
         await loadGroups();
         await loadExpenses();
         yield (DeleteGroupSuccess());
+      }
+      if (event is DeleteFriend) {
+        yield DetailExpLoading();
+        await FriendFunctions.deleteFriend(id: event.friendid);
+        await loadFriends();
+        yield DeleteFriendSuccess();
       }
     } on PlatformException catch (e) {
       yield (DetailExpFailure(message: "Error: ${e.message}"));

--- a/lib/ui/screens/detailed_expense_page/bloc/detailexp_event.dart
+++ b/lib/ui/screens/detailed_expense_page/bloc/detailexp_event.dart
@@ -34,3 +34,12 @@ class DeleteGroup extends DetailexpEvent {
   @override
   List<Object> get props => [groupId];
 }
+
+class DeleteFriend extends DetailexpEvent {
+  final String friendid;
+
+  DeleteFriend({@required this.friendid}) : assert(friendid != null);
+
+  @override
+  List<Object> get props => [friendid];
+}

--- a/lib/ui/screens/detailed_expense_page/bloc/detailexp_state.dart
+++ b/lib/ui/screens/detailed_expense_page/bloc/detailexp_state.dart
@@ -46,3 +46,5 @@ class DetailExpFailure extends DetailexpState {
 }
 
 class DeleteGroupSuccess extends DetailexpState {}
+
+class DeleteFriendSuccess extends DetailexpState {}

--- a/lib/ui/screens/detailed_expense_page/detail_expense_page.dart
+++ b/lib/ui/screens/detailed_expense_page/detail_expense_page.dart
@@ -83,7 +83,7 @@ class DetailExpMainBody extends StatelessWidget {
           arguments: ScreenArguments(homeIndex: 1),
         );
       } else if (state is DeleteFriendSuccess) {
-        Navigator.of(context).pushReplacementNamed(FriendsPage.id);
+        Navigator.of(context).pushReplacementNamed(HomePage.id);
       }
     }, builder: (context, state) {
       if (state is DetailexpInitialState) {

--- a/lib/ui/screens/detailed_expense_page/detail_expense_page.dart
+++ b/lib/ui/screens/detailed_expense_page/detail_expense_page.dart
@@ -107,7 +107,6 @@ class DetailExpMainBody extends StatelessWidget {
                 ),
                 actions: [
                   PopupMenuButton(
-                    // padding: EdgeInsets.all(0),
                     itemBuilder: (_) => <PopupMenuItem<String>>[
                       PopupMenuItem<String>(
                         child: Text(' Delete Friend'),
@@ -117,7 +116,7 @@ class DetailExpMainBody extends StatelessWidget {
                     onSelected: (ans) async {
                       showDialog(
                         context: context,
-                        builder: (context1) => DeleteFriendDialog(
+                        builder: (dialogContext) => DeleteFriendDialog(
                           title: 'Delete Friend',
                           content:
                               'Do you want to delete friend? All the expenses with this friend will also be deleted.',

--- a/lib/ui/screens/detailed_expense_page/detail_expense_page.dart
+++ b/lib/ui/screens/detailed_expense_page/detail_expense_page.dart
@@ -2,6 +2,7 @@ import 'package:contri_app/global/global_helpers.dart';
 import 'package:contri_app/global/logger.dart';
 import 'package:contri_app/global/storage_constants.dart';
 import 'package:contri_app/ui/components/custom_appBar.dart';
+import 'package:contri_app/ui/components/delete_friend_dialog.dart';
 import 'package:contri_app/ui/components/expense_dialog.dart';
 import 'package:contri_app/ui/components/progressIndicator.dart';
 import 'package:contri_app/ui/components/scren_arguments.dart';
@@ -10,6 +11,7 @@ import 'package:contri_app/ui/screens/detailed_expense_page/bloc/detailexp_bloc.
 import 'package:contri_app/ui/screens/edit_expense_page/edit_expense_page.dart';
 import 'package:contri_app/ui/screens/home_page/home_page.dart';
 import 'package:contri_app/ui/screens/home_page/pages/add_expense_page/add_expense_page.dart';
+import 'package:contri_app/ui/screens/home_page/pages/friends_page/friends_page.dart';
 import 'package:firebase_image/firebase_image.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
@@ -80,6 +82,8 @@ class DetailExpMainBody extends StatelessWidget {
           HomePage.id,
           arguments: ScreenArguments(homeIndex: 1),
         );
+      } else if (state is DeleteFriendSuccess) {
+        Navigator.of(context).pushReplacementNamed(FriendsPage.id);
       }
     }, builder: (context, state) {
       if (state is DetailexpInitialState) {
@@ -101,6 +105,31 @@ class DetailExpMainBody extends StatelessWidget {
                     Navigator.of(context).pop();
                   },
                 ),
+                actions: [
+                  PopupMenuButton(
+                    // padding: EdgeInsets.all(0),
+                    itemBuilder: (_) => <PopupMenuItem<String>>[
+                      PopupMenuItem<String>(
+                        child: Text(' Delete Friend'),
+                        value: 'Delete',
+                      ),
+                    ],
+                    onSelected: (ans) async {
+                      showDialog(
+                        context: context,
+                        builder: (context1) => DeleteFriendDialog(
+                          title: 'Delete Friend',
+                          content:
+                              'Do you want to delete friend? All the expenses with this friend will also be deleted.',
+                          onPressed: () async {
+                            BlocProvider.of<DetailexpBloc>(context).add(
+                                DeleteFriend(friendid: arguments.friend.id));
+                          },
+                        ),
+                      );
+                    },
+                  ),
+                ],
               )
             ],
             body: Container(

--- a/lib/ui/screens/edit_expense_page/edit_expense_page.dart
+++ b/lib/ui/screens/edit_expense_page/edit_expense_page.dart
@@ -99,14 +99,14 @@ class EditExpMainBody extends StatelessWidget {
             onPressed: () {
               showDialog(
                 context: context,
-                builder: (context) => ExpenseDialog(
+                builder: (dialogContext) => ExpenseDialog(
                     title: "Delete Expense",
                     onPressed: () {
                       BlocProvider.of<EditexpBloc>(context).add(
                         DeleteExpense(expenseId: argument.id),
                       );
 
-                      Navigator.of(context).pop();
+                      Navigator.of(dialogContext).pop();
                     },
                     content: "Do you really want to delete the expense?",
                     proceedButtonText: "Delete"),
@@ -120,7 +120,7 @@ class EditExpMainBody extends StatelessWidget {
             onPressed: () {
               showDialog(
                 context: context,
-                builder: (context) => ExpenseDialog(
+                builder: (dialogContext) => ExpenseDialog(
                     title: "Settle Up",
                     onPressed: () {
                       BlocProvider.of<EditexpBloc>(context).add(
@@ -139,7 +139,7 @@ class EditExpMainBody extends StatelessWidget {
                         ),
                       );
 
-                      Navigator.of(context).pop();
+                      Navigator.of(dialogContext).pop();
                     },
                     content: "Do you want to settle up this expense?",
                     proceedButtonText: "Settle Up"),
@@ -480,7 +480,7 @@ Widget _buildBottomBar(BuildContext context) {
             onTap: () {
               showDialog(
                 context: context,
-                builder: (context) => AddCommentsBox(
+                builder: (dialogContext) => AddCommentsBox(
                   onAddTap: () {
                     if (!commentsFormKey.currentState.validate()) return;
                     BlocProvider.of<CommentsBloc>(context).add(
@@ -489,10 +489,10 @@ Widget _buildBottomBar(BuildContext context) {
                       ),
                     );
                     commentsController.clear();
-                    Navigator.of(context).pop();
+                    Navigator.of(dialogContext).pop();
                   },
                   onCancelTap: () {
-                    Navigator.of(context).pop();
+                    Navigator.of(dialogContext).pop();
                   },
                   textController: commentsController,
                   formKey: commentsFormKey,

--- a/lib/ui/screens/home_page/pages/add_expense_page/add_expense_page.dart
+++ b/lib/ui/screens/home_page/pages/add_expense_page/add_expense_page.dart
@@ -567,7 +567,7 @@ Widget _buildBottomBar(BuildContext context) {
             onTap: () {
               showDialog(
                 context: context,
-                builder: (context) => AddCommentsBox(
+                builder: (dialogContext) => AddCommentsBox(
                   onAddTap: () {
                     if (!commentsFormKey.currentState.validate()) return;
                     BlocProvider.of<CommentsBloc>(context).add(
@@ -576,10 +576,10 @@ Widget _buildBottomBar(BuildContext context) {
                       ),
                     );
                     commentsController.clear();
-                    Navigator.of(context).pop();
+                    Navigator.of(dialogContext).pop();
                   },
                   onCancelTap: () {
-                    Navigator.of(context).pop();
+                    Navigator.of(dialogContext).pop();
                   },
                   textController: commentsController,
                   formKey: commentsFormKey,

--- a/lib/ui/screens/home_page/pages/friends_page/friends_page.dart
+++ b/lib/ui/screens/home_page/pages/friends_page/friends_page.dart
@@ -165,7 +165,7 @@ class NewFriendButton extends StatelessWidget {
       onPressed: () {
         showDialog(
           context: context,
-          builder: (context) => AddNewFriendDialog(
+          builder: (dialogContext) => AddNewFriendDialog(
             onPressed: () {
               if (!formKey.currentState.validate()) return;
               BlocProvider.of<FriendsBloc>(context).add(
@@ -176,7 +176,7 @@ class NewFriendButton extends StatelessWidget {
                   phoneNumber: phoneNumberController.text,
                 ),
               );
-              Navigator.of(context).pop();
+              Navigator.of(dialogContext).pop();
             },
             formKey: formKey,
             firstNameController: firstNameController,

--- a/lib/ui/screens/home_page/pages/notes_page/notes_page.dart
+++ b/lib/ui/screens/home_page/pages/notes_page/notes_page.dart
@@ -86,17 +86,17 @@ class NotesPageBody extends StatelessWidget {
                           onPressed: () {
                             showDialog(
                               context: context,
-                              builder: (context) => AddCommentsBox(
+                              builder: (dialogContext) => AddCommentsBox(
                                 onAddTap: () {
                                   if (!_formKey.currentState.validate()) return;
 
                                   BlocProvider.of<NotesBloc>(context).add(
                                       AddComment(
                                           comment: _commentController.text));
-                                  Navigator.of(context).pop();
+                                  Navigator.of(dialogContext).pop();
                                 },
                                 onCancelTap: () {
-                                  Navigator.of(context).pop();
+                                  Navigator.of(dialogContext).pop();
                                 },
                                 textController: _commentController,
                                 formKey: _formKey,

--- a/lib/ui/screens/login_page/login_page.dart
+++ b/lib/ui/screens/login_page/login_page.dart
@@ -197,7 +197,7 @@ class _LoginFormState extends State<LoginForm> {
     final _formKey = GlobalKey<FormState>();
     showDialog(
       context: context,
-      builder: (context) => PassResetMailDialog(
+      builder: (dialogContext) => PassResetMailDialog(
         formKey: _formKey,
         emailController: _emailController,
         onPressed: () {


### PR DESCRIPTION
### Description
- Fixed the issue in which new showDialog function API was showing the dialog with a context that wasn't related to a previous context. The Bloc thus, didn't have the required context to add an event.
- Added the option to delete friend.

Fixes #3 
Fixes #37 

### Flutter Channel:
- [x] I have used the Flutter Beta channel on my local machine 

### Type of Change:
- Code

**Code/Quality Assurance Only**
- Bug fix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality pre-approved by mentors)

### How Has This Been Tested?
On a physical device

### Checklist:
**Delete irrelevant options.**

- [x] My PR follows the style guidelines of this project
- [x] I have performed a self-review of my own code or materials
- [x] I have commented my code or provided relevant documentation, particularly in hard-to-understand areas

**Code/Quality Assurance Only**
- [x] My changes generate no new warnings
![Justsplitfix](https://user-images.githubusercontent.com/58694295/104746090-d5386d80-5774-11eb-97cf-ba72a62c0a39.gif)
